### PR TITLE
added prebuild image for tiny calorie + docker compose

### DIFF
--- a/Authelia-Traefik-Integration/docker-compose.yml
+++ b/Authelia-Traefik-Integration/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: dnshra/tinycalorie:1.0
     container_name: tiny-calorie
     volumes: 
-      - /path/to/storage:/app/data
+      - /path/to/storage:/storage
     networks:
       - network
     expose: 

--- a/Authelia-Traefik-Integration/docker-compose.yml
+++ b/Authelia-Traefik-Integration/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.1"
+
+services:
+  tiny-calorie:
+    image: dnshra/tinycalorie:1.0
+    container_name: tiny-calorie
+    volumes: 
+      - /path/to/storage:/app/data
+    networks:
+      - network
+    expose: 
+      - 80
+    restart: unless-stopped
+    labels:
+      # Authelia-Traefik Config
+      - "traefik.enable=true"
+      - 'traefik.http.routers.tinycalorie.tls=true'
+      - "traefik.http.routers.tinycalorie.rule=Host(`domain.TLD`)"
+      - "traefik.http.routers.tinycalorie.entrypoints=websecure"
+      - "traefik.http.routers.tinycalorie.service=tinycalorie"
+      - "traefik.http.services.tinycalorie.loadbalancer.server.port=80"
+      - "traefik.http.routers.tinycalorie.tls.certresolver=leresolver"
+      - 'traefik.http.routers.tinycalorie.middlewares=authelia@docker'
+
+networks:
+  network:
+    external: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,76 @@ This will expose it on port 8080, and store the SQLite db.db in /path/to/storage
 docker build -t tinycalorie .
 docker run -p 8080:80 -v /path/to/storage:/storage tinycalorie
 ```
+## Dockerfile on Dockerhub
+
+### Use the prebuild image on Dockerhub
+[Docker Hub Image](https://hub.docker.com/r/dnshra/tinycalorie)
+```bash
+docker pull dnshra/tinycalorie:1.0
+```
+## Use Docker-Compose File
+1. Install Docker and Docker-Compose
+2. Clone Repository or copy the file below to docker-compose.yml
+3. run docker-compose up -d
+
+[How to install Docker-Compose](https://docs.docker.com/compose/install/)
+
+```
+version: "3.1"
+
+services:
+  tiny-calorie:
+    image: dnshra/tinycalorie:1.0
+    container_name: tiny-calorie
+    volumes: 
+      - /path/to/storage:/app/data
+    networks:
+      - network
+    ports: 
+      - 8080:80
+    restart: unless-stopped
+networks:
+    network:
+```
+
+## Integration with Authelia und Traefik
+1. Install Docker and Docker-Compose
+2. Clone Repository 
+3. Switch to folder Authelia-Traefik-Integration or copy the file below to docker-compose.yml
+3. run docker-compose up -d
+
+[Learn about Authelia](https://www.authelia.com/)
+[Learn about Traefik](hhttps://traefik.io/)
+
+```
+version: "3.1"
+
+services:
+  tiny-calorie:
+    image: dnshra/tinycalorie:1.0
+    container_name: tiny-calorie
+    volumes: 
+      - /path/to/storage:/app/data
+    networks:
+      - network
+    expose: 
+      - 80
+    restart: unless-stopped
+    labels:
+      # Authelia-Traefik Config
+      - "traefik.enable=true"
+      - 'traefik.http.routers.tinycalorie.tls=true'
+      - "traefik.http.routers.tinycalorie.rule=Host(`domain.TLD`)"
+      - "traefik.http.routers.tinycalorie.entrypoints=websecure"
+      - "traefik.http.routers.tinycalorie.service=tinycalorie"
+      - "traefik.http.services.tinycalorie.loadbalancer.server.port=80"
+      - "traefik.http.routers.tinycalorie.tls.certresolver=leresolver"
+      - 'traefik.http.routers.tinycalorie.middlewares=authelia@docker'
+
+networks:
+  network:
+    external: true
+```
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ services:
     image: dnshra/tinycalorie:1.0
     container_name: tiny-calorie
     volumes: 
-      - /path/to/storage:/app/data
+      - /path/to/storage:/storage
     networks:
       - network
     ports: 
@@ -61,7 +61,7 @@ services:
     image: dnshra/tinycalorie:1.0
     container_name: tiny-calorie
     volumes: 
-      - /path/to/storage:/app/data
+      - /path/to/storage:/storage
     networks:
       - network
     expose: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.1"
+
+services:
+  tiny-calorie:
+    image: dnshra/tinycalorie:1.0
+    container_name: tiny-calorie
+    volumes: 
+      - /path/to/storage:/app/data
+    networks:
+      - network
+    ports: 
+      - 8080:80
+    restart: unless-stopped
+networks:
+    network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: dnshra/tinycalorie:1.0
     container_name: tiny-calorie
     volumes: 
-      - /path/to/storage:/app/data
+      - /path/to/storage:/storage
     networks:
       - network
     ports: 


### PR DESCRIPTION
1. I prebuild the tiny calorie dockerimage and published it on docker hub
2. added a simple docker-compose file for easy integration with something like portainer
3. worte a fully integrated version into my authelia and traefik stack